### PR TITLE
Switch to LS rust-crypto fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["twilio","rust"]
 hyper = "^0.10"
 hyper-native-tls = "^0.3"
 mime = "^0.2"
-rust-crypto = "^0.2"
+rust-crypto = { git = "https://github.com/lendsmartpub/rust-crypto.git" }
 url="^1.0"
 serde = "1.0.10"
 serde_derive = "1.0.10"


### PR DESCRIPTION
This PR switches from the original rust-crypto to LS fork of it.